### PR TITLE
Docs edits

### DIFF
--- a/1.Hello-World/Hello-World/ViewController.swift
+++ b/1.Hello-World/Hello-World/ViewController.swift
@@ -13,7 +13,7 @@ let kWidgetHeight = 240
 let kWidgetWidth = 320
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/1.Hello-World/README.md
+++ b/1.Hello-World/README.md
@@ -12,8 +12,8 @@ Application Notes
     the OpenTok iOS SDK.
 
 *   In the VideoController.swift file, set values for the `kApiKey`, `kSessionId`,
-    and `kToken` constants. For testing, you can obtain these values at the
-    [OpenTok dashboard][1]. In a production application, use one of the
+    and `kToken` constants. For testing, you can obtain these values at your
+    [OpenTok account page][1]. In a production application, use one of the
     [OpenTok server SDKs][2] to generate session IDs and tokens.
 
 *   By default, all delegate methods from classes in the OpenTok iOS SDK are
@@ -65,5 +65,5 @@ Configuration Notes
     the iOS Simulator, an OTPublisher object uses a demo video instead of the
     camera.
 
-[1]: https://dashboard.tokbox.com/projects
-[2]: https://tokbox.com/opentok/libraries/server/
+[1]: https://tokbox.com/account/#/
+[2]: https://tokbox.com/developer/sdks/server/

--- a/2.Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
+++ b/2.Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
@@ -13,7 +13,7 @@ let kWidgetHeight = 240
 let kWidgetWidth = 320
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/3.Custom-Audio-Driver/3.Custom-Audio-Driver/ViewController.swift
+++ b/3.Custom-Audio-Driver/3.Custom-Audio-Driver/ViewController.swift
@@ -13,7 +13,7 @@ let kWidgetHeight = 240
 let kWidgetWidth = 320
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/3.Custom-Audio-Driver/README.md
+++ b/3.Custom-Audio-Driver/README.md
@@ -6,7 +6,8 @@ The entry point of new content is during the controllers `viewDidLoad()`
 callback, where we set up an audio device before initializing our first OpenTok
 object. It is important to note that audio device setup *must* occur before any
 instance of OTSession or OTPublisher is initialized:
-```
+
+```swift
 let customAudioDevice = DefaultAudioDevice.sharedInstance
 OTAudioDeviceManager.setAudioDevice(customAudioDevice)
 ```

--- a/4.Screen-Sharing/4.Screen-Sharing/ViewController.swift
+++ b/4.Screen-Sharing/4.Screen-Sharing/ViewController.swift
@@ -13,7 +13,7 @@ let kWidgetHeight = 240
 let kWidgetWidth = 320
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/4.Screen-Sharing/README.md
+++ b/4.Screen-Sharing/README.md
@@ -24,15 +24,17 @@ This custom video capturer is defined by the ScreenCapture class:
         defer {
             process(error: error)
         }
-        publisher = OTPublisher(delegate: self, name: UIDevice.current.name)
+        let settings = OTPublisherSettings()
+        settings.name = UIDevice.current.name
+        publisher = OTPublisher(delegate: self, settings: settings)
         publisher?.videoType = .screen
         publisher?.audioFallbackEnabled = false
         
         capturer = ScreenCapturer(withView: view)
-        publisher?.videoCapture = capturer?.videoCapture()
+        publisher?.videoCapture = capturer!.videoCapture()
         
         var error: OTError? = nil
-        session.publish(publisher, error: &error)
+        session.publish(publisher!, error: &error)
     }
 
 Note that the call to the `OTPublisher.videoType` method sets the
@@ -64,7 +66,7 @@ The `viewDidLoad` method initialized a OTVideoFormat and OTVideoFrame object to
 be used by the custom video capturer:
 
     let format = OTVideoFormat()
-		format.pixelFormat = .argb
+    format.pixelFormat = .argb
 
 The `consumeFrame()` method sets up properties of the current video frame:
 

--- a/5.Live-Photo-Capture/Live-Photo-Capture/ViewController.swift
+++ b/5.Live-Photo-Capture/Live-Photo-Capture/ViewController.swift
@@ -13,7 +13,7 @@ let kWidgetHeight = 240
 let kWidgetWidth = 320
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/5.Live-Photo-Capture/README.md
+++ b/5.Live-Photo-Capture/README.md
@@ -14,7 +14,7 @@ Configuration Notes
 Since we are importing a number of classes implemented in project 2, the
 header search paths in the project build settings must be extended to look
 in the project 2 directory. Additionally, we must recompile the
-implementation files in order to continue using our TBExamplePublisher,
+implementation files in order to continue using our ExamplePublisher,
 created in project 2. You will notice an extra group in this project's
 navigator space with references to the files we need.
 

--- a/6.Simple-Multiparty/6.Simple-Multiparty/ViewController.swift
+++ b/6.Simple-Multiparty/6.Simple-Multiparty/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import OpenTok
 
 // *** Fill the following variables using your own Project info  ***
-// ***          https://dashboard.tokbox.com/projects            ***
+// ***            https://tokbox.com/account/#/                  ***
 // Replace with your OpenTok API key
 let kApiKey = ""
 // Replace with your generated session ID

--- a/6.Simple-Multiparty/README.md
+++ b/6.Simple-Multiparty/README.md
@@ -72,5 +72,4 @@ class is invoked:
 ## Next steps
 
 For details on the full OpenTok Android API, see the [reference
-documentation](https://tokbox.com/opentok/libraries/client/ios/reference/index.html).
-
+documentation](https://tokbox.com/developer/sdks/ios/reference/index.html).

--- a/browser-demo.html
+++ b/browser-demo.html
@@ -16,10 +16,10 @@
   <div id="subscribersContainer"></div>
   <div id="signals"></div>
 
-<script src='http://static.opentok.com/webrtc/v2.2/js/TB.min.js'></script>
+<script src='http://static.opentok.com/webrtc/v2/js/TB.min.js'></script>
 <script type="text/javascript" charset="utf-8">
   // *** Fill the following variables using your own Project info from the Dashboard  ***
-  // ***                  (https://dashboard.tokbox.com/projects)                     ***
+  // ***                      (https://tokbox.com/account/#/)                         ***
 
   var apiKey = '';    // Replace with your own API key.
   var sessionId = ''; // Replace with your generated session ID.


### PR DESCRIPTION
A few things in Swift are new to me. From your docs, I guess that what Objective-C would call `[OTSession.initWithApiKey(apiKey:sessionId:delegate:]` is called `OTSession.initWithApiKey(_:, sessionId:,delegate:)` in Swift. Is that correct?

* The readme for the custom audio driver sample refers to `recording_cb` and `playout_cb`. I cannot find those in the code.

* The readme for the screen-sharing sample refers to the following code, which I cannot locate
  in the source code:

      let format = OTVideoFormat()
      format.pixelFormat = .argb
