### PR TITLE
OPENTOK-40576: iOS Stream Mirroring issues fixed

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -58,6 +58,8 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
     
     var delegate: FrameCapturerMetadataDelegate?
     
+    var cameraPosition: AVCaptureDevice.Position = .unspecified
+    
     fileprivate var capturePreset: AVCaptureSession.Preset {
         didSet {
             (captureWidth, captureHeight) = capturePreset.dimensionForCapturePreset()
@@ -68,7 +70,7 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
     fileprivate var captureHeight: UInt32
     fileprivate var capturing = false
     fileprivate let videoFrame: OTVideoFrame
-    fileprivate var videoFrameOrientation: OTVideoOrientation = .up
+    fileprivate var videoFrameOrientation: OTVideoOrientation = .left  //potrait
     
     let captureQueue: DispatchQueue
     
@@ -102,7 +104,8 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
                 print("Failed to acquire camera device for video")
                 return
         }
-
+        cameraPosition = .front
+        
         videoInput = try AVCaptureDeviceInput(device: device)
         guard let videoInput = self.videoInput else {
             print("There was an error creating videoInput")
@@ -238,14 +241,18 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
             do {
                 if position == AVCaptureDevice.Position.back {
                     guard let backFacingCamera = backFacingCamera() else { return nil }
+                    cameraPosition = .back
                     return try AVCaptureDeviceInput.init(device: backFacingCamera)
                 } else if position == AVCaptureDevice.Position.front {
                     guard let frontFacingCamera = frontFacingCamera() else { return nil }
+                    cameraPosition = .front
                     return try AVCaptureDeviceInput.init(device: frontFacingCamera)
                 } else {
+                    cameraPosition = .unspecified
                     return nil
                 }
             } catch {
+                cameraPosition = .unspecified
                 return nil
             }
         }()

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -111,7 +111,6 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
                 print("Failed to acquire camera device for video")
                 return
         }
-       
         videoInput = try AVCaptureDeviceInput(device: device)
         guard let videoInput = self.videoInput else {
             print("There was an error creating videoInput")

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -58,7 +58,14 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
     
     var delegate: FrameCapturerMetadataDelegate?
     
-    var cameraPosition: AVCaptureDevice.Position = .unspecified
+    var cameraPosition: AVCaptureDevice.Position {
+        get {
+            if let videoInput=videoInput {
+                return videoInput.device.position
+            }
+            return .unspecified
+        }
+    }
     
     fileprivate var capturePreset: AVCaptureSession.Preset {
         didSet {
@@ -104,8 +111,7 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
                 print("Failed to acquire camera device for video")
                 return
         }
-        cameraPosition = .front
-        
+       
         videoInput = try AVCaptureDeviceInput(device: device)
         guard let videoInput = self.videoInput else {
             print("There was an error creating videoInput")
@@ -241,18 +247,14 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
             do {
                 if position == AVCaptureDevice.Position.back {
                     guard let backFacingCamera = backFacingCamera() else { return nil }
-                    cameraPosition = .back
                     return try AVCaptureDeviceInput.init(device: backFacingCamera)
                 } else if position == AVCaptureDevice.Position.front {
                     guard let frontFacingCamera = frontFacingCamera() else { return nil }
-                    cameraPosition = .front
                     return try AVCaptureDeviceInput.init(device: frontFacingCamera)
                 } else {
-                    cameraPosition = .unspecified
                     return nil
                 }
             } catch {
-                cameraPosition = .unspecified
                 return nil
             }
         }()

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -60,10 +60,7 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
     
     var cameraPosition: AVCaptureDevice.Position {
         get {
-            if let videoInput=videoInput {
-                return videoInput.device.position
-            }
-            return .unspecified
+            videoInput?.device.position ?? .unspecified
         }
     }
     

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoRender.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoRender.swift
@@ -16,24 +16,21 @@ protocol ExampleVideoRenderDelegate {
 class ExampleVideoRender: UIView {
     
     var delegate: ExampleVideoRenderDelegate?
-    
     var mirroring: Bool = true {
-        willSet(newValue) {
-            renderer?.mirroring = newValue
+        didSet {
+            if let renderer = renderer {
+                renderer.mirroring = mirroring
+            }
         }
     }
     
     fileprivate var glContext: EAGLContext?
     fileprivate var renderer: EAGLVideoRenderer?
     fileprivate var glkView: GLKView?
-    
     fileprivate var frameLock: NSLock?
-    
     fileprivate var renderingEnabled: Bool = true
     fileprivate var clearRenderer = 0
-    
     fileprivate var lastVideoFrame: OTVideoFrame?
-    
     fileprivate var displayLinkProxy: DisplayLinkProxy?
     fileprivate var displayLink: CADisplayLink?
     
@@ -41,15 +38,14 @@ class ExampleVideoRender: UIView {
         super.init(frame: frame)
         glContext = EAGLContext(api:.openGLES2)
         renderer = EAGLVideoRenderer(context: glContext!)
+       
         glkView = GLKView(frame: CGRect.zero, context: glContext!)
-        
         glkView?.drawableColorFormat = .RGBA8888
         glkView?.drawableDepthFormat = .formatNone
         glkView?.drawableStencilFormat = .formatNone
         glkView?.drawableMultisample = .multisampleNone
         glkView?.delegate = self;
         glkView?.layer.masksToBounds = true;
-        
         addSubview(glkView!)
         
         frameLock = NSLock()

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoRender.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoRender.swift
@@ -17,6 +17,12 @@ class ExampleVideoRender: UIView {
     
     var delegate: ExampleVideoRenderDelegate?
     
+    var mirroring: Bool = true {
+        willSet(newValue) {
+            renderer?.mirroring = newValue
+        }
+    }
+    
     fileprivate var glContext: EAGLContext?
     fileprivate var renderer: EAGLVideoRenderer?
     fileprivate var glkView: GLKView?
@@ -61,6 +67,7 @@ class ExampleVideoRender: UIView {
         displayLink!.frameInterval = 2
         displayLink!.add(to: RunLoop.main, forMode: RunLoop.Mode.common)
         
+        renderer!.mirroring = mirroring
         renderer!.setupGL()
         
         displayLink!.isPaused = false

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
@@ -112,9 +112,7 @@ class ViewController: UIViewController {
     
     
     @IBAction func toggleCamera(_ sender: Any) {
-        if let capturer = publisher?.videoCapture as? ExampleVideoCapture,
-            let renderer = publisher?.videoRender as? ExampleVideoRender {
-            
+        if let capturer = publisher?.videoCapture as? ExampleVideoCapture, let renderer = publisher?.videoRender as? ExampleVideoRender {
             let _ = capturer.toggleCameraPosition()
             renderer.mirroring = (capturer.cameraPosition == AVCaptureDevice.Position.front) ? true : false
         }

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.swift
@@ -112,8 +112,11 @@ class ViewController: UIViewController {
     
     
     @IBAction func toggleCamera(_ sender: Any) {
-        if let capturer = publisher?.videoCapture as? ExampleVideoCapture {
+        if let capturer = publisher?.videoCapture as? ExampleVideoCapture,
+            let renderer = publisher?.videoRender as? ExampleVideoRender {
+            
             let _ = capturer.toggleCameraPosition()
+            renderer.mirroring = (capturer.cameraPosition == AVCaptureDevice.Position.front) ? true : false
         }
     }
 }

--- a/Live-Photo-Capture/Live-Photo-Capture/ViewController.swift
+++ b/Live-Photo-Capture/Live-Photo-Capture/ViewController.swift
@@ -86,13 +86,12 @@ class ViewController: UIViewController {
         pubSettings.name = UIDevice.current.name
         publisher = OTPublisher(delegate: self, settings: pubSettings)
         if let pub = publisher {
+            let videoRender = ExampleVideoRender()
+            pub.videoRender = videoRender
             pub.videoCapture = photoVideoCapture
             session.publish(pub, error: &error)
-            
-            if let pubView = pub.view {
-                pubView.frame = CGRect(x: 0, y: 0, width: kWidgetWidth, height: kWidgetHeight)
-                view.addSubview(pubView)
-            }
+            videoRender.frame = CGRect(x: 0, y: 0, width: kWidgetWidth, height: kWidgetHeight)
+            view.addSubview(videoRender)
         }
     }
     


### PR DESCRIPTION
1) The `Custom-Video-Driver` swift project mirroring was turned off by default in the front camera.
2) The orientation of the publisher video was incorrect. Changed to portrait.
3)cameraPosition var added . This will give us the current active camera position being used.As a side effect it sets the renderer mirroring property.
4) Mirroring turned on by default in ExampleVideoRenderer
5) toogleCamera function now checks for camera position and adjusts mirroring property accordingly.
6) Live-Photo-Capture project now uses ExampleVideoRender object instead of the default, to account for mirroring when back camera is active.
