### PR TITLE
OPENTOK-40693:Enable background modes of projects for the property Audio,AirPlay,PIP r=robjperez

### DIFF
--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Basic-Video-Chat/Basic-Video-Chat/Info.plist
+++ b/Basic-Video-Chat/Basic-Video-Chat/Info.plist
@@ -22,6 +22,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,9 +44,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.pbxproj
+++ b/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Custom-Audio-Driver/Custom-Audio-Driver/Info.plist
+++ b/Custom-Audio-Driver/Custom-Audio-Driver/Info.plist
@@ -20,6 +20,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -34,9 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/Custom-Video-Driver/Custom-Video-Driver.xcodeproj/project.pbxproj
+++ b/Custom-Video-Driver/Custom-Video-Driver.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Info.plist
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Info.plist
@@ -22,6 +22,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,9 +44,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/FrameMetadata/FrameMetadata.xcodeproj/project.pbxproj
+++ b/FrameMetadata/FrameMetadata.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/FrameMetadata/FrameMetadata/Info.plist
+++ b/FrameMetadata/FrameMetadata/Info.plist
@@ -28,6 +28,10 @@
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.pbxproj
+++ b/Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Live-Photo-Capture/Live-Photo-Capture/Info.plist
+++ b/Live-Photo-Capture/Live-Photo-Capture/Info.plist
@@ -22,6 +22,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -36,9 +44,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/Multiparty-UICollectionView/Multiparty-UICollectionView.xcodeproj/project.pbxproj
+++ b/Multiparty-UICollectionView/Multiparty-UICollectionView.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Multiparty-UICollectionView/Multiparty-UICollectionView/Info.plist
+++ b/Multiparty-UICollectionView/Multiparty-UICollectionView/Info.plist
@@ -24,6 +24,10 @@
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
+++ b/Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Screen-Sharing/Screen-Sharing/Info.plist
+++ b/Screen-Sharing/Screen-Sharing/Info.plist
@@ -20,6 +20,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -34,9 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>

--- a/Simple-Multiparty/Simple-Multiparty.xcodeproj/project.pbxproj
+++ b/Simple-Multiparty/Simple-Multiparty.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Simple-Multiparty/Simple-Multiparty/Info.plist
+++ b/Simple-Multiparty/Simple-Multiparty/Info.plist
@@ -20,6 +20,14 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string></string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -34,9 +42,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSCameraUsageDescription</key>
-	<string></string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
An offshoot of the issue - https://github.com/opentok/opentok-ios-sdk-samples-swift/issues/75
Many users miss this step and they panic and have to ping Customer Support, learn about it, make the change and waste valuable time.
Xcode version: 11.3.1