### PR TITLE
update basic video chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode11
 before_install:
   - pod repo update > /dev/null
 script: ./travis_build.sh 

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 					F86C64991D5C7C630081846D = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = "";
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = 1200;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -107,6 +107,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -211,7 +212,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -259,7 +260,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -278,7 +279,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -291,7 +292,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tokbox.Hello-World";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/xcshareddata/xcschemes/Basic-Video-Chat.xcscheme
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/xcshareddata/xcschemes/Basic-Video-Chat.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Basic-Video-Chat.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Basic-Video-Chat.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Basic-Video-Chat/Podfile
+++ b/Basic-Video-Chat/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '12.0'
 use_frameworks!
 
 require_relative '../OpenTokSDKVersion'

--- a/Basic-Video-Chat/Podfile.lock
+++ b/Basic-Video-Chat/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.15.0)
+  - OpenTok (2.18.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.15.0)
+  - OpenTok (= 2.18.1)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: f2729ddade8dae49f233b22670dc795ecd236660
+  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
 
-PODFILE CHECKSUM: 5d5d67221d38bc9f64ee6b0f086eae6bcf9072ca
+PODFILE CHECKSUM: e3d18095ac30da6bb9782b278dd84a6c8ca22a3e
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.10.0.rc.1

--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,1 +1,1 @@
-OpenTokSDKVersion = '2.18.0'
+OpenTokSDKVersion = '2.18.1'


### PR DESCRIPTION
Upgraded SDK to 2.18.1

For all the projects I moved the min ios version to ios 12, updated them to use swift 5, cleaned up all the project warnings and deprecations that arose too.