### PR TITLE
update samples for sdk 2.20.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode12.5
 before_install:
   - pod repo update > /dev/null
 script: ./travis_build.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode12.5
+osx_image: xcode11.7
 before_install:
   - pod repo update > /dev/null
 script: ./travis_build.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: objective-c
 osx_image: xcode11.7
 before_install:
-  - gem install cocoapods
   - pod repo update > /dev/null
 script: ./travis_build.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 osx_image: xcode11.7
 before_install:
+  - gem install cocoapods
   - pod repo update > /dev/null
 script: ./travis_build.sh 

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64";
 			};
 			name = Debug;
 		};
@@ -265,6 +266,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64";
 			};
 			name = Release;
 		};

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/xcshareddata/xcschemes/Basic-Video-Chat.xcscheme
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/xcshareddata/xcschemes/Basic-Video-Chat.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1170"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Basic-Video-Chat/Podfile.lock
+++ b/Basic-Video-Chat/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: e3d18095ac30da6bb9782b278dd84a6c8ca22a3e
 

--- a/Basic-Video-Chat/Podfile.lock
+++ b/Basic-Video-Chat/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: e3d18095ac30da6bb9782b278dd84a6c8ca22a3e
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/Basic-Video-Chat/Podfile.lock
+++ b/Basic-Video-Chat/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: e3d18095ac30da6bb9782b278dd84a6c8ca22a3e
 

--- a/Custom-Audio-Driver/Podfile.lock
+++ b/Custom-Audio-Driver/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: eace414ef730b2e460c5040a4fefef7c62a2745a
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/Custom-Audio-Driver/Podfile.lock
+++ b/Custom-Audio-Driver/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: eace414ef730b2e460c5040a4fefef7c62a2745a
 

--- a/Custom-Audio-Driver/Podfile.lock
+++ b/Custom-Audio-Driver/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: eace414ef730b2e460c5040a4fefef7c62a2745a
 

--- a/Custom-Video-Driver/Podfile.lock
+++ b/Custom-Video-Driver/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: 3c973495e9949904e51fc303ae9b761f8f6db77d
 

--- a/Custom-Video-Driver/Podfile.lock
+++ b/Custom-Video-Driver/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: 3c973495e9949904e51fc303ae9b761f8f6db77d
 

--- a/Custom-Video-Driver/Podfile.lock
+++ b/Custom-Video-Driver/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: 3c973495e9949904e51fc303ae9b761f8f6db77d
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/FrameMetadata/Podfile.lock
+++ b/FrameMetadata/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: 3462ecf4ec1b675cf2f8665d77f7db71e391f379
 

--- a/FrameMetadata/Podfile.lock
+++ b/FrameMetadata/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: 3462ecf4ec1b675cf2f8665d77f7db71e391f379
 

--- a/FrameMetadata/Podfile.lock
+++ b/FrameMetadata/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: 3462ecf4ec1b675cf2f8665d77f7db71e391f379
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/Live-Photo-Capture/Podfile.lock
+++ b/Live-Photo-Capture/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: efae206ed400b0d7d68c425811c3a89c6c670270
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/Live-Photo-Capture/Podfile.lock
+++ b/Live-Photo-Capture/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: efae206ed400b0d7d68c425811c3a89c6c670270
 

--- a/Live-Photo-Capture/Podfile.lock
+++ b/Live-Photo-Capture/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: efae206ed400b0d7d68c425811c3a89c6c670270
 

--- a/Multiparty-UICollectionView/Podfile.lock
+++ b/Multiparty-UICollectionView/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.15.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.15.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: f2729ddade8dae49f233b22670dc795ecd236660
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: 553690ccb7a83e387910f9d0537502e82549eb1e
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.10.1

--- a/Multiparty-UICollectionView/Podfile.lock
+++ b/Multiparty-UICollectionView/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: 553690ccb7a83e387910f9d0537502e82549eb1e
 

--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,1 +1,1 @@
-OpenTokSDKVersion = '2.19.1'
+OpenTokSDKVersion = '2.20.0'

--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,1 +1,1 @@
-OpenTokSDKVersion = '2.19.0'
+OpenTokSDKVersion = '2.19.1'

--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,1 +1,1 @@
-OpenTokSDKVersion = '2.18.1'
+OpenTokSDKVersion = '2.19.0'

--- a/Screen-Sharing/Podfile.lock
+++ b/Screen-Sharing/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: 0098343079672c3f696a5ee6739910a16cdabcb5
 

--- a/Screen-Sharing/Podfile.lock
+++ b/Screen-Sharing/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: 0098343079672c3f696a5ee6739910a16cdabcb5
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/Screen-Sharing/Podfile.lock
+++ b/Screen-Sharing/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: 0098343079672c3f696a5ee6739910a16cdabcb5
 

--- a/Simple-Multiparty/Podfile.lock
+++ b/Simple-Multiparty/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.0)
+  - OpenTok (2.19.1)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.0)
+  - OpenTok (= 2.19.1)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 3ac356cce06545a573234582702abaf671d44909
+  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
 
 PODFILE CHECKSUM: ec3904194bdf3baef5bcfd4f642012ed6f5538c5
 

--- a/Simple-Multiparty/Podfile.lock
+++ b/Simple-Multiparty/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - OpenTok (2.19.1)
+  - OpenTok (2.20.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.19.1)
+  - OpenTok (= 2.20.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 0c4b4f336462ed5e2aa18b9868eed971f922a09f
+  OpenTok: 414c2c1dc6486f1897015e4d1703558d5eed48c3
 
 PODFILE CHECKSUM: ec3904194bdf3baef5bcfd4f642012ed6f5538c5
 

--- a/Simple-Multiparty/Podfile.lock
+++ b/Simple-Multiparty/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - OpenTok (2.18.1)
+  - OpenTok (2.19.0)
 
 DEPENDENCIES:
-  - OpenTok (= 2.18.1)
+  - OpenTok (= 2.19.0)
 
 SPEC REPOS:
   trunk:
     - OpenTok
 
 SPEC CHECKSUMS:
-  OpenTok: 2a816f5d77fbf2e2ebb5aec841bd21fb7dc7737b
+  OpenTok: 3ac356cce06545a573234582702abaf671d44909
 
 PODFILE CHECKSUM: ec3904194bdf3baef5bcfd4f642012ed6f5538c5
 
-COCOAPODS: 1.10.0.rc.1
+COCOAPODS: 1.10.1

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -4,28 +4,28 @@ set -e
 
 cd Basic-Video-Chat/
 pod install
-xcodebuild -workspace Basic-Video-Chat.xcworkspace  -scheme Basic-Video-Chat -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Basic-Video-Chat.xcworkspace  -scheme Basic-Video-Chat -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Custom-Video-Driver/
 pod install
-xcodebuild -workspace Custom-Video-Driver.xcworkspace  -scheme Custom-Video-Driver -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Custom-Video-Driver.xcworkspace  -scheme Custom-Video-Driver -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Custom-Audio-Driver/
 pod install
-xcodebuild -workspace Custom-Audio-Driver.xcworkspace  -scheme Custom-Audio-Driver -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Custom-Audio-Driver.xcworkspace  -scheme Custom-Audio-Driver -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Screen-Sharing/
 pod install
-xcodebuild -workspace Screen-Sharing.xcworkspace  -scheme Screen-Sharing -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Screen-Sharing.xcworkspace  -scheme Screen-Sharing -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Live-Photo-Capture/
 pod install
-xcodebuild -workspace Live-Photo-Capture.xcworkspace  -scheme Live-Photo-Capture -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Live-Photo-Capture.xcworkspace  -scheme Live-Photo-Capture -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Simple-Multiparty/
 pod install
-xcodebuild -workspace Simple-Multiparty.xcworkspace  -scheme Simple-Multiparty -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Simple-Multiparty.xcworkspace  -scheme Simple-Multiparty -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO
 
 cd ../Multiparty-UICollectionView/
 pod install
-xcodebuild -workspace Multiparty-UICollectionView.xcworkspace  -scheme Multiparty-UICollectionView -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO
+xcodebuild -workspace Multiparty-UICollectionView.xcworkspace  -scheme Multiparty-UICollectionView -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -UseModernBuildSystem=NO


### PR DESCRIPTION
Updated the podfiles and checked if each sample worked correctly. Similarly to the objc repo there are warnings about webrtc , which will fail the CI. I think they can be silenced https://discuss.newrelic.com/t/direct-access-linker-warnings/79965

passing now with 2.20.0 and old build system