### PR TITLE
OPENTOK-43389:  Garbled video with  iOS SDK when setting capturePreset to AVCaptureSession.Preset.medium

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -319,9 +319,10 @@ extension ExampleVideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate {
         }
         
         let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        CVPixelBufferLockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
         
         videoCaptureConsumer?.consumeImageBuffer(imageBuffer, orientation: videoFrameOrientation, timestamp: time, metadata: videoFrame.metadata)
         
-        CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)));
+        CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
     }
 }

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -308,11 +308,9 @@ extension ExampleVideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate {
     
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection)
     {
-        if !capturing || videoCaptureConsumer == nil {
-            return
-        }
-        
-        guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+        guard capturing,
+              let videoCaptureConsumer = videoCaptureConsumer,
+              let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
             else {
                 print("Error acquiring sample buffer")
                 return
@@ -321,7 +319,7 @@ extension ExampleVideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate {
         let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         CVPixelBufferLockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
         
-        videoCaptureConsumer?.consumeImageBuffer(imageBuffer, orientation: videoFrameOrientation, timestamp: time, metadata: videoFrame.metadata)
+        videoCaptureConsumer.consumeImageBuffer(imageBuffer, orientation: videoFrameOrientation, timestamp: time, metadata: videoFrame.metadata)
         
         CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
     }

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -318,46 +318,9 @@ extension ExampleVideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate {
                 return
         }
         
-        guard let videoInput = videoInput
-            else {
-                print("Capturer does not have a valid input")
-                return
-        }
-        
         let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-        CVPixelBufferLockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)))
         
-        videoFrame.timestamp = time
-        let height = UInt32(CVPixelBufferGetHeight(imageBuffer))
-        let width = UInt32(CVPixelBufferGetWidth(imageBuffer))
-        
-        if width != captureWidth || height != captureHeight {
-            updateCaptureFormat(width: width, height: height)
-        }
-        
-        videoFrame.format?.imageWidth = width
-        videoFrame.format?.imageHeight = height
-        let minFrameDuration = videoInput.device.activeVideoMinFrameDuration
-        
-        videoFrame.format?.estimatedFramesPerSecond = Double(minFrameDuration.timescale) / Double(minFrameDuration.value)
-        videoFrame.format?.estimatedCaptureDelay = 100
-        videoFrame.orientation = self.videoFrameOrientation
-        
-        videoFrame.clearPlanes()
-        
-        if !CVPixelBufferIsPlanar(imageBuffer) {
-            videoFrame.planes?.addPointer(CVPixelBufferGetBaseAddress(imageBuffer))
-        } else {
-            for idx in 0..<CVPixelBufferGetPlaneCount(imageBuffer) {
-                videoFrame.planes?.addPointer(CVPixelBufferGetBaseAddressOfPlane(imageBuffer, idx))
-            }
-        }
-        
-        if let delegate = delegate {
-            delegate.finishPreparingFrame(videoFrame)
-        }
-        
-        videoCaptureConsumer!.consumeFrame(videoFrame)
+        videoCaptureConsumer?.consumeImageBuffer(imageBuffer, orientation: videoFrameOrientation, timestamp: time, metadata: videoFrame.metadata)
         
         CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: CVOptionFlags(0)));
     }


### PR DESCRIPTION
#### What is this PR doing?

Replacing `consumeFrame`  with `consumeImageBuffer`  for `OTVideoCaptureConsumer`.

#### How should this be manually tested?

Set `AVCaptureSession.Preset.medium` as capture preset on `Custom-Video-Driver` and run the app.

#### What are the relevant tickets?

[OPENTOK-43389](https://jira.vonage.com/browse/OPENTOK-43389)
