### PR TITLE
ContentHint compatibility code added for custom capturers

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ExampleVideoCapture.swift
@@ -52,6 +52,7 @@ protocol FrameCapturerMetadataDelegate {
 }
 
 class ExampleVideoCapture: NSObject, OTVideoCapture {
+    var videoContentHint: OTVideoContentHint
     var captureSession: AVCaptureSession?
     var videoInput: AVCaptureDeviceInput?
     var videoOutput: AVCaptureVideoDataOutput?
@@ -90,6 +91,7 @@ class ExampleVideoCapture: NSObject, OTVideoCapture {
     }
     
     override init() {
+        self.videoContentHint = .none
         capturePreset = AVCaptureSession.Preset.vga640x480
         captureQueue = DispatchQueue(label: "com.tokbox.VideoCapture", attributes: [])
         (captureWidth, captureHeight) = capturePreset.dimensionForCapturePreset()

--- a/Screen-Sharing/Screen-Sharing/ScreenCapturer.swift
+++ b/Screen-Sharing/Screen-Sharing/ScreenCapturer.swift
@@ -10,6 +10,7 @@ import Foundation
 import OpenTok
 
 class ScreenCapturer: NSObject, OTVideoCapture {
+    var videoContentHint: OTVideoContentHint
     var videoCaptureConsumer: OTVideoCaptureConsumer?
 
     let MAX_EDGE_SIZE_LIMIT: CGFloat = 1280.0
@@ -23,6 +24,7 @@ class ScreenCapturer: NSObject, OTVideoCapture {
     fileprivate var pixelBuffer: CVPixelBuffer?
     
     init(withView: UIView) {
+        self.videoContentHint = .none
         captureView = withView        
         timer = DispatchSource.makeTimerSource(flags: .strict, queue: captureQueue)
     }

--- a/Screen-Sharing/Screen-Sharing/ViewController.swift
+++ b/Screen-Sharing/Screen-Sharing/ViewController.swift
@@ -83,6 +83,7 @@ class ViewController: UIViewController {
         
         capturer = ScreenCapturer(withView: view)
         publisher?.videoCapture = capturer
+        publisher?.videoCapture?.videoContentHint = .text
         
         session.publish(publisher!, error: &error)
     }


### PR DESCRIPTION
The screen sharing app shows how to use the content hint.
The other capturers just initializes the hint to .none