### PR TITLE
OPENTOK-48681: Assign range to playoutDelay

### DIFF
--- a/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
+++ b/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
@@ -293,6 +293,7 @@ extension DefaultAudioDevice: OTAudioDevice {
         return recording
     }
     func estimatedRenderDelay() -> UInt16 {
+        //No problem with casting. plaoutDelay will never be bigger than 1000
         return UInt16(playoutDelay)
     }
     func estimatedCaptureDelay() -> UInt16 {
@@ -630,20 +631,29 @@ func updatePlayoutDelay(withAudioDevice audioDevice: DefaultAudioDevice) {
     audioDevice.playoutDelayMeasurementCounter += 1
     if audioDevice.playoutDelayMeasurementCounter >= 100 {
         // Update HW and OS delay every second, unlikely to change
-        audioDevice.playoutDelay = 0
+        var tempPlayoutDelay: UInt32 = 0
         let session = AVAudioSession.sharedInstance()
         
         // HW output latency
         let interval = session.outputLatency
-        audioDevice.playoutDelay += UInt32(interval * 1000000)
+        tempPlayoutDelay += UInt32(interval * 1000000)
         // HW buffer duration
         let ioInterval = session.ioBufferDuration
-        audioDevice.playoutDelay += UInt32(ioInterval * 1000000)
-        audioDevice.playoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)
+        tempPlayoutDelay += UInt32(ioInterval * 1000000)
+        tempPlayoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)
         // To ms
-        audioDevice.playoutDelay = (audioDevice.playoutDelay - 500) / 1000
+        tempPlayoutDelay = (audioDevice.playoutDelay - 500) / 1000
         
-        audioDevice.playoutDelayMeasurementCounter = 0
+        //playout valid interval [0 - 1000]ms
+        if(tempPlayoutDelay > 1000)
+        {
+            //input parameter error
+            audioDevice.playoutDelayMeasurementCounter = 100
+        } else
+        {
+            audioDevice.playoutDelay = tempPlayoutDelay
+            audioDevice.playoutDelayMeasurementCounter = 0
+        }
     }
 }
 


### PR DESCRIPTION
**What is this PR doing?**
Assign range to playoutDelay [0 - 1000]ms
Case value is outside range, means there is a nonsense input variable, so playoutDelay is triggered to be calculated again.

**How should this be manually tested?**
tbd (waiting for traces from https://jira.vonage.com/browse/OPENTOK-48681)

**What are the relevant tickets?**
[OPENTOK-48681](https://jira.vonage.com/browse/OPENTOK-48681)