### PR TITLE
OPENTOK-48681: Avoid crash on cast

### DIFF
--- a/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
+++ b/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
@@ -20,6 +20,7 @@ class DefaultAudioDevice: NSObject {
     static let kAudioDeviceHeadset = "AudioSessionManagerDevice_Headset"
     static let kAudioDeviceBluetooth = "AudioSessionManagerDevice_Bluetooth"
     static let kAudioDeviceSpeaker = "AudioSessionManagerDevice_Speaker"
+    static let kStandardPlayoutDelay: UInt8 = 15
     
     var audioFormat = OTAudioFormat()
     let safetyQueue = DispatchQueue(label: "ot-audio-driver")
@@ -293,6 +294,7 @@ extension DefaultAudioDevice: OTAudioDevice {
         return recording
     }
     func estimatedRenderDelay() -> UInt16 {
+        //No problem with casting. plaoutDelay will never be bigger than 1000
         return UInt16(playoutDelay)
     }
     func estimatedCaptureDelay() -> UInt16 {
@@ -630,20 +632,33 @@ func updatePlayoutDelay(withAudioDevice audioDevice: DefaultAudioDevice) {
     audioDevice.playoutDelayMeasurementCounter += 1
     if audioDevice.playoutDelayMeasurementCounter >= 100 {
         // Update HW and OS delay every second, unlikely to change
-        audioDevice.playoutDelay = 0
+        var tempPlayoutDelay: UInt32 = 0
         let session = AVAudioSession.sharedInstance()
         
         // HW output latency
         let interval = session.outputLatency
-        audioDevice.playoutDelay += UInt32(interval * 1000000)
+        tempPlayoutDelay += UInt32(interval * 1000000)
         // HW buffer duration
         let ioInterval = session.ioBufferDuration
-        audioDevice.playoutDelay += UInt32(ioInterval * 1000000)
-        audioDevice.playoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)
+        tempPlayoutDelay += UInt32(ioInterval * 1000000)
+        tempPlayoutDelay += UInt32(audioDevice.playoutAudioUnitPropertyLatency * 1000000)
         // To ms
-        audioDevice.playoutDelay = (audioDevice.playoutDelay - 500) / 1000
+        if( tempPlayoutDelay >= 500 ) {
+            tempPlayoutDelay = (tempPlayoutDelay - 500) / 1000
+        } else {
+            tempPlayoutDelay = UInt32(DefaultAudioDevice.kStandardPlayoutDelay)
+        }
         
-        audioDevice.playoutDelayMeasurementCounter = 0
+        //playout valid interval [0 - 1000]ms
+        if(tempPlayoutDelay > 1000)
+        {
+            //input parameter error
+            audioDevice.playoutDelayMeasurementCounter = 100
+        } else
+        {
+            audioDevice.playoutDelay = tempPlayoutDelay
+            audioDevice.playoutDelayMeasurementCounter = 0
+        }
     }
 }
 


### PR DESCRIPTION
What is this PR doing?

Add range to audio playout delay, in case of incorrect inputs.

Ticket: https://jira.vonage.com/browse/OPENTOK-48681