### PR TITLE
OPENTOK-50698: Fix issue where can't hear audio after disconnect

### DIFF
--- a/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
+++ b/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
@@ -109,7 +109,7 @@ class DefaultAudioDevice: NSObject {
     }
     
     fileprivate func doRestartAudio(numberOfAttempts: Int) {
-        
+        isResetting = true
         if recording {
             let _ = stopCapture()
             disposeAudioUnit(audioUnit: &recordingVoiceUnit)


### PR DESCRIPTION
#### What is this PR doing?

Fixes an issue where audio can't be hear after disconnecting from a session.

#### How should this be manually tested?

There are 2 ways to reproduce the bug.

1st:
1- join the video call from the custom-audio app and opentok playground (playground should hear the voice from app)
2- disconnect the session from the app
3- reconnect and republish to the session from the app
4- you will find the playground cnt hear the voice from the app anymore

2nd:
1- connect the phone to a bluetooth earphone, then join the video call from the custom-audio app, and opentok playground (playground should hear the voice from app)
2- in your phone, go to setting -> bluetooth, then turn off the bluetooth
3- in your phone, go back to the app
4- you will find the playground cnt hear the voice from the app anymore

in short, you cant hear the voice from the app once the function doRestartAudio being triggered by handleRouteChangeEvent.