### PR TITLE
VIDCS-1915: Check if subs are present or not

### DIFF
--- a/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
+++ b/Custom-Audio-Driver/Custom-Audio-Driver/DefaultAudioDevice.swift
@@ -398,7 +398,7 @@ extension DefaultAudioDevice: OTAudioDevice {
         
         freeupAudioBuffers()
         
-        if !recording && !isRecorderInterrupted && !isResetting {
+        if !playing && !isRecorderInterrupted && !isResetting {
             tearDownAudio()
         }
         


### PR DESCRIPTION
If subs are not present tear down the audio session on stopCapture

**Test**: In a 1-1 conversation, publishAudio off on one side will disable the subscriber incoming audio on that side too. This PR fixes it