### PR TITLE
VIDCS-2620: Camera access is not released by the iOS SDK after disconnecting from the session

### DIFF
--- a/Basic-Video-Chat/Basic-Video-Chat/ViewController.swift
+++ b/Basic-Video-Chat/Basic-Video-Chat/ViewController.swift
@@ -93,8 +93,8 @@ class ViewController: UIViewController {
     }
     
     fileprivate func cleanupPublisher() {
-        publisher = nil
         publisher!.view?.removeFromSuperview()
+        publisher = nil
     }
     
     fileprivate func processError(_ error: OTError?) {
@@ -117,6 +117,8 @@ extension ViewController: OTSessionDelegate {
     
     func sessionDidDisconnect(_ session: OTSession) {
         print("Session disconnected")
+        cleanupPublisher()
+        cleanupSubscriber()
     }
     
     func session(_ session: OTSession, streamCreated stream: OTStream) {

--- a/Basic-Video-Chat/Basic-Video-Chat/ViewController.swift
+++ b/Basic-Video-Chat/Basic-Video-Chat/ViewController.swift
@@ -26,12 +26,7 @@ class ViewController: UIViewController {
         return OTSession(apiKey: kApiKey, sessionId: kSessionId, delegate: self)!
     }()
     
-    lazy var publisher: OTPublisher = {
-        let settings = OTPublisherSettings()
-        settings.name = UIDevice.current.name
-        return OTPublisher(delegate: self, settings: settings)!
-    }()
-    
+    var publisher: OTPublisher?
     var subscriber: OTSubscriber?
     
     override func viewDidLoad() {
@@ -64,9 +59,13 @@ class ViewController: UIViewController {
             processError(error)
         }
         
-        session.publish(publisher, error: &error)
+        let settings = OTPublisherSettings()
+        settings.name = UIDevice.current.name
+        publisher =  OTPublisher(delegate: self, settings: settings)!
+
+        session.publish(publisher!, error: &error)
         
-        if let pubView = publisher.view {
+        if let pubView = publisher!.view {
             pubView.frame = CGRect(x: 0, y: 0, width: kWidgetWidth, height: kWidgetHeight)
             view.addSubview(pubView)
         }
@@ -94,7 +93,8 @@ class ViewController: UIViewController {
     }
     
     fileprivate func cleanupPublisher() {
-        publisher.view?.removeFromSuperview()
+        publisher = nil
+        publisher!.view?.removeFromSuperview()
     }
     
     fileprivate func processError(_ error: OTError?) {


### PR DESCRIPTION
Code changes:

1. Make publisher an optional and nil out in cleanup, so camera access is given up
2. Session disconnect callback also cleans up Publisher and subscribers

As per [OTSession SDK documentation](https://tokbox.com/developer/sdks/ios/reference/Classes/OTSession.html#//api/name/publish:error:)   a session publish action "adds" a publisher  and an unpublish action "removes" a publisher from the session object. Since the session does not "create" a publisher , it will also not "destroy" it on unpublish. Hence an explicit "nil" assignment is needed in `cleanupPublisher` function  so that camera access is given up in "this" app. Think of adding and removing an object to an array in any programming language code. The removed object is not destroyed implicitly.

If your app re-uses the publisher immediately or it is used to hold onto its view, there is no need to "nil" it out. You can recycle the same publisher object in the next new session. 